### PR TITLE
Adjusts css to make bottom navigation bar visible on mobile devices too

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
         <link rel="icon" type="image/png" href="/homectl-icon.png" />
         <link rel="manifest" href="/manifest.json" />
       </head>
-      <body className="flex h-screen flex-col overflow-hidden">
+      <body className="flex flex-col overflow-hidden">
         <ColorPickerModal />
         <SaveSceneModal />
         <SceneModal />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -13,4 +13,7 @@
     /* Disables pull-to-refresh and overscroll effects. */
     overscroll-behavior: none;
   }
+  html, body {
+    height: 100%;
+  }
 }


### PR DESCRIPTION
The dashboard's bottom navigation bar was not visible in case the device had the bottom android navigation bar applied, i.e., 
![image](https://user-images.githubusercontent.com/7705285/234386781-d3b16152-b27f-43a7-af28-8723e180b353.png)
